### PR TITLE
Add from_string function to MXFPMeta and MinifloatMeta

### DIFF
--- a/src/mase_triton/mxfp/meta.py
+++ b/src/mase_triton/mxfp/meta.py
@@ -1,4 +1,5 @@
 import functools
+import re
 from dataclasses import dataclass
 
 import torch
@@ -45,7 +46,6 @@ class MXFPMeta:
         Returns:
             MXFPMeta instance
         """
-        import re
         pattern = r"MXFP_E(?P<exp>\d+)M(?P<frac>\d+)_B(?P<block>\d+)_S(?P<scale>\d+)(?:_(?P<finite>fn|inf))?$"
         match = re.fullmatch(pattern, config, flags=re.IGNORECASE)
         if not match:


### PR DESCRIPTION
This PR introduces `from_string()` classmethods to `MXFPMeta` and `MinifloatMeta`, allowing flexible and consistent parsing of string-encoded metadata formats for quantizer configuration.