### PR TITLE
fix: contiguous-ize OTLinear input before kernel dispatch

### DIFF
--- a/src/mase_triton/optical_compute/layers.py
+++ b/src/mase_triton/optical_compute/layers.py
@@ -63,6 +63,8 @@ class OpticalTransformerLinear(torch.nn.Linear):
         if self.bypass:
             return super().forward(x)
 
+        x = x.contiguous()
+
         if self.training:
             with torch.no_grad():
                 x_min_max = optical_transformer_update_qstats(

--- a/test/test_optical_compute_quantized_layers.py
+++ b/test/test_optical_compute_quantized_layers.py
@@ -66,3 +66,31 @@ def test_optical_compute_quantized_linear_forward_error(device):
         assert error < 0.05
     logger.info(f"ErrorNorm/Norm: {error}")
     logger.info("Test passed: output is close to reference")
+
+
+@pytest.mark.parametrize(
+    "device", ["cpu", "cuda"] if torch.cuda.is_available() else ["cpu"]
+)
+def test_optical_compute_quantized_linear_non_contiguous_input(device):
+    # Regression: RoBERTa's classification head feeds the linear a sliced
+    # `features[:, 0, :]`, which is non-contiguous. The kernel asserts
+    # contiguity, so the layer wrapper must contiguous-ize before dispatch.
+    in_features = 32
+    out_features = 8
+    fc = OpticalTransformerLinear(
+        in_features=in_features,
+        out_features=out_features,
+        bias=True,
+        device=device,
+        dtype=torch.float32,
+    )
+    features = torch.rand(2, 4, in_features, device=device, dtype=torch.float32)
+    x = features[:, 0, :]
+    assert not x.is_contiguous()
+    with torch.no_grad():
+        fc.eval()
+        y_eval = fc(x)
+        fc.train()
+        y_train = fc(x)
+    assert y_eval.shape == (2, out_features)
+    assert y_train.shape == (2, out_features)


### PR DESCRIPTION
The CUDA `ot_qlinear_fn` triton op asserts `x.is_contiguous()`, but common consumers (e.g. RoBERTa's classification head, which passes `features[:, 0, :]`) feed sliced — and therefore non-contiguous — tensors. The CPU impl tolerates this but the GPU path crashed at end-of-epoch eval. Mirror the convention already used in NewComputeBench ot_roberta.py for `quantized_matmul_fn` callers (`.contiguous()` at the call site) and add a regression test exercising a sliced input on both cpu and cuda.